### PR TITLE
Fix include paths in fuse_texs

### DIFF
--- a/arxiv_tools.py
+++ b/arxiv_tools.py
@@ -25,7 +25,7 @@ def fuse_texs(dir_path: pathlib.Path, tex_source: str) -> str:
     input_regex = re.compile(r'\\input{(.*)}')
 
     for include in reversed(list(input_regex.finditer(tex_source))):
-        include_path = dir_path / pathlib.Path(include.group(1) + '.tex')
+        include_path = dir_path / pathlib.Path(include.group(1)).with_suffix(".tex")
 
         with open(include_path, 'r') as file:
             content = file.read() + '\n\n'


### PR DESCRIPTION
`\input` commands can have the filename with and without the file extension.
Instead of adding a `.tex` extension no matter the argument to `include`, we replace the extension.